### PR TITLE
Apply split documentation and software licensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All material changes to the public ABR framework should be recorded here.
 
+## August 19, 2026 - Split Repository Licensing
+
+### Changed
+
+- Documentation and other non-code materials are designated CC BY-NC-SA 4.0.
+- Software source code and scripts are MIT-licensed only when expressly identified as such.
+- Added clear contribution-licensing rules and commercial-licensing contact information.
+- Preserved notice that permissions already granted for earlier MIT-licensed repository versions are not revoked.
+
 ## August 2026 - Governance Framework Refresh
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,13 @@ Never include private keys, seed phrases, recovery material, credentials, person
 ## Current Reserve Goal
 
 The 21 BTC figure is ABR's long-term goal, not its current balance. Contributions must not describe the goal as current holdings.
+
+## Contribution Licensing
+
+Unless a pull request clearly states otherwise and ABR agrees in writing:
+
+- Documentation and other non-code contributions are submitted under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+- Software source-code and script contributions are submitted under the [MIT License](LICENSES/MIT.txt) and should be clearly identified as MIT-licensed.
+
+By submitting a contribution, you confirm that you created it or otherwise have the right to submit it under the applicable license. See [LICENSE](LICENSE) for the repository's full licensing notice.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,65 @@
-MIT License
+ABR REPOSITORY LICENSING NOTICE
 
-Copyright (c) 2025 tolbyus
+Copyright (c) 2025-2026 Tolbyus Shephard
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This repository uses separate licenses for documentation and software code.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. DOCUMENTATION AND OTHER NON-CODE MATERIALS
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless a file expressly states otherwise, the documentation and other non-code
+materials in this repository are licensed under the Creative Commons
+Attribution-NonCommercial-ShareAlike 4.0 International Public License
+(CC BY-NC-SA 4.0).
+
+This includes README files, Markdown and text documents, PDF documents,
+governance frameworks, policies, educational materials, diagrams, and other
+non-code creative materials.
+
+Official legal terms:
+https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
+
+A copy of the license reference is located at:
+LICENSES/CC-BY-NC-SA-4.0.txt
+
+The license permits sharing and adaptation for NonCommercial purposes, provided
+the user gives appropriate attribution, links to the license, indicates
+changes, and distributes adapted material under the same license or a
+BY-NC-SA-compatible license.
+
+Suggested attribution:
+"Altgeld Bitcoin Reserve, created by Tolbyus Shephard,"
+with a link to:
+https://github.com/tolbyus/Altgeld-Bitcoin-Reserve
+
+Commercial use is not granted by CC BY-NC-SA 4.0. For a separate commercial
+license or written permission, contact the Altgeld Bitcoin Reserve through:
+https://altgeldbitcoinreserve.com/
+
+2. SOFTWARE CODE
+
+Software source code and scripts are licensed under the MIT License only when
+the file is expressly identified as MIT-licensed, such as with the SPDX
+identifier "SPDX-License-Identifier: MIT", or when a repository notice
+specifically designates that file or directory as MIT-licensed.
+
+A document, policy, framework, PDF, diagram, or other non-code material is not
+MIT-licensed merely because it is stored in a GitHub repository.
+
+The full MIT License is located at:
+LICENSES/MIT.txt
+
+3. THIRD-PARTY MATERIALS AND RESERVED RIGHTS
+
+Third-party materials remain subject to their own licenses or terms. This
+notice does not grant trademark, publicity, privacy, patent, or endorsement
+rights. The Altgeld Bitcoin Reserve name, logos, and branding may not be used
+to imply sponsorship, approval, or official status without permission.
+
+4. EARLIER REPOSITORY VERSIONS
+
+Earlier repository versions were released under the MIT License, including its
+reference to associated documentation. Permissions already granted for those
+historical versions remain in effect and are not revoked by this change.
+
+The licensing notice included with each repository version should be consulted
+for the terms offered with that version.

--- a/LICENSES/CC-BY-NC-SA-4.0.txt
+++ b/LICENSES/CC-BY-NC-SA-4.0.txt
@@ -1,0 +1,12 @@
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+(CC BY-NC-SA 4.0)
+
+Official legal code:
+https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
+
+Human-readable summary:
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+The official, unmodified Creative Commons legal code at the URL above controls.
+The repository's root LICENSE file identifies the materials to which this
+license is applied and provides the requested attribution.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Tolbyus Shephard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,11 @@ Bitcoin is volatile. The Reserve's value may decline substantially, including fo
 This material is not an offer to sell or a solicitation to buy any security or interest. It is not investment, legal, tax, or accounting advice and creates no rights. The governing documents of ABR Wealth Fund DAO LLC and ABR Foundation control.
 
 Maintained by **Tolbyus Shephard**, founder of the Altgeld Bitcoin Reserve.
+
+## License
+
+- **Documentation and other non-code materials:** [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) - sharing and adaptation are allowed for noncommercial purposes with attribution and ShareAlike.
+- **Software code and scripts:** [MIT](https://opensource.org/license/mit) only when the file or directory is expressly identified as MIT-licensed.
+
+Commercial use of ABR documentation requires separate written permission. See the repository [LICENSE](LICENSE) for the scope, requested attribution, commercial-licensing contact, and the notice concerning earlier repository versions.
+


### PR DESCRIPTION
## What changed

- Replaces the single repository-wide MIT notice with a clear split-license notice.
- Applies CC BY-NC-SA 4.0 to documentation and other non-code materials.
- Keeps the standard MIT License for software code and scripts that are expressly identified as MIT-licensed.
- Adds license references, README disclosure, contribution terms, commercial-licensing contact information, and a changelog entry.
- Records that earlier MIT permissions remain effective for historical repository versions.

## Why

ABR wants communities to be able to share and adapt its public framework for noncommercial purposes with attribution and ShareAlike, while reserving commercial implementation and licensing opportunities. Software code remains permissively licensed when it is clearly marked.

## Impact

The current repository is documentation-focused. Its governance documents, PDFs, policies, and related non-code materials are designated CC BY-NC-SA 4.0. Commercial use requires separate permission. Future code is MIT only when expressly identified.

## Validation

- Compared the branch with `main`: one commit, six files, no unrelated changes.
- Confirmed the MIT file uses the standard unmodified MIT text.
- Confirmed the CC notice links to Creative Commons' official legal code.
- Confirmed the README, contributing guide, and changelog describe the same license split.
